### PR TITLE
fix fb string

### DIFF
--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -103,8 +103,13 @@ private:
     void GenerateFBEFieldModelPMRBytes_Source();
     void GenerateFBEFieldModelString_Header();
     void GenerateFBEFieldModelString_Source();
+    // TODO(liuqi): exists for backwards compatibility
     void GenerateFBEFieldModelPMRString_Header();
     void GenerateFBEFieldModelPMRString_Source();
+    void GenerateFBEFieldModelMemoryString_Header();
+    void GenerateFBEFieldModelMemoryString_Source();
+    void GenerateFBEFieldModelMemoryArenaString_Header();
+    void GenerateFBEFieldModelMemoryArenaString_Source();
     void GenerateFBEFieldModelOptional_Header();
     void GenerateFBEFieldModelOptional_Inline();
     void GenerateFBEFieldModelStructOptional_Header();

--- a/proto/fbe_json.h
+++ b/proto/fbe_json.h
@@ -80,6 +80,15 @@ struct KeyWriter<TWriter, stdb::memory::string>
     }
 };
 
+template <class TWriter>
+struct KeyWriter<TWriter, stdb::memory::arena_string>
+{
+    static bool to_json_key(TWriter& writer, const stdb::memory::arena_string& key)
+    {
+        return writer.Key(key.c_str());
+    }
+};
+
 template <class TWriter, size_t N>
 struct KeyWriter<TWriter, char[N]>
 {
@@ -257,6 +266,15 @@ struct ValueWriter<TWriter, stdb::memory::string>
     }
 };
 
+template <class TWriter>
+struct ValueWriter<TWriter, stdb::memory::arena_string>
+{
+    static bool to_json(TWriter& writer, const stdb::memory::arena_string& value, bool scope = true)
+    {
+        return writer.String(value.c_str());
+    }
+};
+
 template <class TWriter, std::size_t N>
 struct ValueWriter<TWriter, char[N]>
 {
@@ -427,6 +445,15 @@ template <class TJson>
 struct KeyReader<TJson, stdb::memory::string>
 {
     static bool from_json_key(const TJson& json, stdb::memory::string& key)
+    {
+        return FBE::JSON::from_json(json, key);
+    }
+};
+
+template <class TJson>
+struct KeyReader<TJson, stdb::memory::arena_string>
+{
+    static bool from_json_key(const TJson& json, stdb::memory::arena_string& key)
     {
         return FBE::JSON::from_json(json, key);
     }
@@ -751,6 +778,23 @@ template <class TJson>
 struct ValueReader<TJson, stdb::memory::string>
 {
     static bool from_json(const TJson& json, stdb::memory::string& value)
+    {
+        value = "";
+
+        // Schema validation
+        if (json.IsNull() || !json.IsString())
+            return false;
+
+        // Save the value
+        value.assign(json.GetString(), (size_t)json.GetStringLength());
+        return true;
+    }
+};
+
+template <class TJson>
+struct ValueReader<TJson, stdb::memory::arena_string>
+{
+    static bool from_json(const TJson& json, stdb::memory::arena_string& value)
     {
         value = "";
 

--- a/proto/fbe_models.h
+++ b/proto/fbe_models.h
@@ -308,6 +308,108 @@ private:
 
 // Fast Binary Encoding field model string specialization
 template <>
+class FieldModel<std::pmr::string>
+{
+public:
+    FieldModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset) {}
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 4; }
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the string value is valid
+    bool verify() const noexcept;
+
+    // Get the string value
+    size_t get(char* data, size_t size) const noexcept;
+    // Get the string value
+    template <size_t N>
+    size_t get(char (&data)[N]) const noexcept { return get(data, N); }
+    // Get the string value
+    template <size_t N>
+    size_t get(std::array<char, N>& data) const noexcept { return get(data.data(), data.size()); }
+    // Get the pmr string value
+    void get(std::pmr::string& value) const noexcept;
+    // Get the pmr string value
+    void get(std::pmr::string& value, const std::pmr::string& defaults) const noexcept;
+
+    // Set the string value
+    void set(const char* data, size_t size);
+    // Set the string value
+    template <size_t N>
+    void set(const char (&data)[N]) { set(data, N); }
+    // Set the string value
+    template <size_t N>
+    void set(const std::array<char, N>& data) { set(data.data(), data.size()); }
+    // Set the string value
+    void set(const std::pmr::string& value);
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+};
+
+// Fast Binary Encoding field model string specialization
+template <>
+class FieldModel<stdb::memory::string>
+{
+public:
+    FieldModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset) {}
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 4; }
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the string value is valid
+    bool verify() const noexcept;
+
+    // Get the string value
+    size_t get(char* data, size_t size) const noexcept;
+    // Get the string value
+    template <size_t N>
+    size_t get(char (&data)[N]) const noexcept { return get(data, N); }
+    // Get the string value
+    template <size_t N>
+    size_t get(std::array<char, N>& data) const noexcept { return get(data.data(), data.size()); }
+    // Get the pmr string value
+    void get(stdb::memory::string& value) const noexcept;
+    // Get the pmr string value
+    void get(stdb::memory::string& value, const stdb::memory::string& defaults) const noexcept;
+
+    // Set the string value
+    void set(const char* data, size_t size);
+    // Set the string value
+    template <size_t N>
+    void set(const char (&data)[N]) { set(data, N); }
+    // Set the string value
+    template <size_t N>
+    void set(const std::array<char, N>& data) { set(data.data(), data.size()); }
+    // Set the string value
+    void set(const stdb::memory::string& value);
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+};
+
+// Fast Binary Encoding field model string specialization
+template <>
 class FieldModel<stdb::memory::arena_string>
 {
 public:

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -6670,7 +6670,6 @@ struct KeyReader<TJson, stdb::memory::arena_string>
     }
 };
 
-t
 template <class TJson>
 struct KeyReader<TJson, FBE::decimal_t>
 {

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -2618,8 +2618,128 @@ private:
     Write(code);
 }
 
-
 void GeneratorCpp::GenerateFBEFieldModelPMRString_Header()
+{
+    std::string code = R"CODE(
+// Fast Binary Encoding field model string specialization
+template <>
+class FieldModel<std::pmr::string>
+{
+public:
+    FieldModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset) {}
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 4; }
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the string value is valid
+    bool verify() const noexcept;
+
+    // Get the string value
+    size_t get(char* data, size_t size) const noexcept;
+    // Get the string value
+    template <size_t N>
+    size_t get(char (&data)[N]) const noexcept { return get(data, N); }
+    // Get the string value
+    template <size_t N>
+    size_t get(std::array<char, N>& data) const noexcept { return get(data.data(), data.size()); }
+    // Get the pmr string value
+    void get(std::pmr::string& value) const noexcept;
+    // Get the pmr string value
+    void get(std::pmr::string& value, const std::pmr::string& defaults) const noexcept;
+
+    // Set the string value
+    void set(const char* data, size_t size);
+    // Set the string value
+    template <size_t N>
+    void set(const char (&data)[N]) { set(data, N); }
+    // Set the string value
+    template <size_t N>
+    void set(const std::array<char, N>& data) { set(data.data(), data.size()); }
+    // Set the string value
+    void set(const std::pmr::string& value);
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+};
+)CODE";
+
+    // Prepare code template
+    code = std::regex_replace(code, std::regex("\n"), EndLine());
+
+    Write(code);
+}
+void GeneratorCpp::GenerateFBEFieldModelMemoryString_Header()
+{
+    std::string code = R"CODE(
+// Fast Binary Encoding field model string specialization
+template <>
+class FieldModel<stdb::memory::string>
+{
+public:
+    FieldModel(FBEBuffer& buffer, size_t offset) noexcept : _buffer(buffer), _offset(offset) {}
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 4; }
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    // Check if the string value is valid
+    bool verify() const noexcept;
+
+    // Get the string value
+    size_t get(char* data, size_t size) const noexcept;
+    // Get the string value
+    template <size_t N>
+    size_t get(char (&data)[N]) const noexcept { return get(data, N); }
+    // Get the string value
+    template <size_t N>
+    size_t get(std::array<char, N>& data) const noexcept { return get(data.data(), data.size()); }
+    // Get the pmr string value
+    void get(stdb::memory::string& value) const noexcept;
+    // Get the pmr string value
+    void get(stdb::memory::string& value, const stdb::memory::string& defaults) const noexcept;
+
+    // Set the string value
+    void set(const char* data, size_t size);
+    // Set the string value
+    template <size_t N>
+    void set(const char (&data)[N]) { set(data, N); }
+    // Set the string value
+    template <size_t N>
+    void set(const std::array<char, N>& data) { set(data.data(), data.size()); }
+    // Set the string value
+    void set(const stdb::memory::string& value);
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+};
+)CODE";
+
+    // Prepare code template
+    code = std::regex_replace(code, std::regex("\n"), EndLine());
+
+    Write(code);
+}
+
+void GeneratorCpp::GenerateFBEFieldModelMemoryArenaString_Header()
 {
     std::string code = R"CODE(
 // Fast Binary Encoding field model string specialization
@@ -2837,6 +2957,318 @@ void FieldModel<std::string>::set(const std::string& value)
 }
 
 void GeneratorCpp::GenerateFBEFieldModelPMRString_Source()
+{
+    std::string code = R"CODE(
+size_t FieldModel<std::pmr::string>::fbe_extra() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if ((fbe_string_offset == 0) || ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size()))
+        return 0;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    return (size_t)(4 + fbe_string_size);
+}
+
+bool FieldModel<std::pmr::string>::verify() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return true;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if (fbe_string_offset == 0)
+        return true;
+
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return false;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return false;
+
+    return true;
+}
+
+size_t FieldModel<std::pmr::string>::get(char* data, size_t size) const noexcept
+{
+    assert(((size == 0) || (data != nullptr)) && "Invalid buffer!");
+    if ((size > 0) && (data == nullptr))
+        return 0;
+
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if (fbe_string_offset == 0)
+        return 0;
+
+    assert(((_buffer.offset() + fbe_string_offset + 4) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    assert(((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return 0;
+
+    size_t result = std::min(size, (size_t)fbe_string_size);
+    memcpy(data, (const char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), result);
+    return result;
+}
+
+void FieldModel<std::pmr::string>::get(std::pmr::string& value) const noexcept
+{
+    value.clear();
+
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + _offset);
+    if (fbe_string_offset == 0)
+        return;
+
+    assert(((_buffer.offset() + fbe_string_offset + 4) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    assert(((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return;
+
+    value.assign((const char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), fbe_string_size);
+}
+
+void FieldModel<std::pmr::string>::get(std::pmr::string& value, const std::pmr::string& defaults) const noexcept
+{
+    value = defaults;
+
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + _offset);
+    if (fbe_string_offset == 0)
+        return;
+
+    assert(((_buffer.offset() + fbe_string_offset + 4) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    assert(((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return;
+
+    value.assign((const char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), fbe_string_size);
+}
+
+void FieldModel<std::pmr::string>::set(const char* data, size_t size)
+{
+    assert(((size == 0) || (data != nullptr)) && "Invalid buffer!");
+    if ((size > 0) && (data == nullptr))
+        return;
+
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = (uint32_t)size;
+    uint32_t fbe_string_offset = (uint32_t)(_buffer.allocate(4 + fbe_string_size) - _buffer.offset());
+    assert(((fbe_string_offset > 0) && ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_string_offset == 0) || ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size()))
+        return;
+
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
+
+
+    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
+}
+
+void FieldModel<std::pmr::string>::set(const std::pmr::string& value)
+{
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = (uint32_t)value.size();
+    uint32_t fbe_string_offset = (uint32_t)(_buffer.allocate(4 + fbe_string_size) - _buffer.offset());
+    assert(((fbe_string_offset > 0) && ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_string_offset == 0) || ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size()))
+        return;
+
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
+
+    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
+}
+)CODE";
+
+    // Prepare code template
+    code = std::regex_replace(code, std::regex("\n"), EndLine());
+
+    Write(code);
+}
+
+void GeneratorCpp::GenerateFBEFieldModelMemoryString_Source()
+{
+    std::string code = R"CODE(
+size_t FieldModel<stdb::memory::string>::fbe_extra() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if ((fbe_string_offset == 0) || ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size()))
+        return 0;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    return (size_t)(4 + fbe_string_size);
+}
+
+bool FieldModel<stdb::memory::string>::verify() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return true;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if (fbe_string_offset == 0)
+        return true;
+
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return false;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return false;
+
+    return true;
+}
+
+size_t FieldModel<stdb::memory::string>::get(char* data, size_t size) const noexcept
+{
+    assert(((size == 0) || (data != nullptr)) && "Invalid buffer!");
+    if ((size > 0) && (data == nullptr))
+        return 0;
+
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset());
+    if (fbe_string_offset == 0)
+        return 0;
+
+    assert(((_buffer.offset() + fbe_string_offset + 4) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return 0;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    assert(((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return 0;
+
+    size_t result = std::min(size, (size_t)fbe_string_size);
+    memcpy(data, (const char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), result);
+    return result;
+}
+
+void FieldModel<stdb::memory::string>::get(stdb::memory::string& value) const noexcept
+{
+    value.clear();
+
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + _offset);
+    if (fbe_string_offset == 0)
+        return;
+
+    assert(((_buffer.offset() + fbe_string_offset + 4) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    assert(((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return;
+
+    value.assign((const char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), fbe_string_size);
+}
+
+void FieldModel<stdb::memory::string>::get(stdb::memory::string& value, const stdb::memory::string& defaults) const noexcept
+{
+    value = defaults;
+
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_offset = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + _offset);
+    if (fbe_string_offset == 0)
+        return;
+
+    assert(((_buffer.offset() + fbe_string_offset + 4) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset);
+    assert(((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size())
+        return;
+
+    value.assign((const char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), fbe_string_size);
+}
+
+void FieldModel<stdb::memory::string>::set(const char* data, size_t size)
+{
+    assert(((size == 0) || (data != nullptr)) && "Invalid buffer!");
+    if ((size > 0) && (data == nullptr))
+        return;
+
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = (uint32_t)size;
+    uint32_t fbe_string_offset = (uint32_t)(_buffer.allocate(4 + fbe_string_size) - _buffer.offset());
+    assert(((fbe_string_offset > 0) && ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_string_offset == 0) || ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size()))
+        return;
+
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
+
+
+    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), data, fbe_string_size);
+}
+
+void FieldModel<stdb::memory::string>::set(const stdb::memory::string& value)
+{
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return;
+
+    uint32_t fbe_string_size = (uint32_t)value.size();
+    uint32_t fbe_string_offset = (uint32_t)(_buffer.allocate(4 + fbe_string_size) - _buffer.offset());
+    assert(((fbe_string_offset > 0) && ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_string_offset == 0) || ((_buffer.offset() + fbe_string_offset + 4 + fbe_string_size) > _buffer.size()))
+        return;
+
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_offset(), fbe_string_offset);
+    unaligned_store<uint32_t>(_buffer.data() + _buffer.offset() + fbe_string_offset, fbe_string_size);
+
+    memcpy((char*)(_buffer.data() + _buffer.offset() + fbe_string_offset + 4), value.data(), fbe_string_size);
+}
+)CODE";
+
+    // Prepare code template
+    code = std::regex_replace(code, std::regex("\n"), EndLine());
+
+    Write(code);
+}
+
+void GeneratorCpp::GenerateFBEFieldModelMemoryArenaString_Source()
 {
     std::string code = R"CODE(
 size_t FieldModel<stdb::memory::arena_string>::fbe_extra() const noexcept
@@ -7403,6 +7835,8 @@ void GeneratorCpp::GenerateFBEModels_Header(const CppCommon::Path& path)
     GenerateFBEFieldModelPMRBytes_Header();
     GenerateFBEFieldModelString_Header();
     GenerateFBEFieldModelPMRString_Header();
+    GenerateFBEFieldModelMemoryString_Header();
+    GenerateFBEFieldModelMemoryArenaString_Header();
     GenerateFBEFieldModelOptional_Header();
     GenerateFBEFieldModelArray_Header();
     GenerateFBEFieldModelVector_Header();
@@ -7484,6 +7918,8 @@ void GeneratorCpp::GenerateFBEModels_Source(const CppCommon::Path& path)
     GenerateFBEFieldModelPMRBytes_Source();
     GenerateFBEFieldModelString_Source();
     GenerateFBEFieldModelPMRString_Source();
+    GenerateFBEFieldModelMemoryString_Source();
+    GenerateFBEFieldModelMemoryArenaString_Source();
 
     // Generate namespace end
     WriteLine();


### PR DESCRIPTION
1. remove unexpected t
2. keep `FieldModel<std::pmr::string>` for backwards compatibility.